### PR TITLE
Fix issue #22

### DIFF
--- a/smilerating/src/main/java/com/hsalf/smilerating/SmileRating.java
+++ b/smilerating/src/main/java/com/hsalf/smilerating/SmileRating.java
@@ -498,11 +498,10 @@ public class SmileRating extends BaseRating {
     }
 
     private void moveSmileByFraction(float fraction) {
-        if (fraction >= 0f && fraction <= 1f) {
-            getSmiley(mSmileys, fraction, divisions, mFromRange, mToRange,
-                    mFaceCenter, mSmilePath, mCenterY);
-            invalidate();
-        }
+        fraction = Math.max(Math.min(fraction, 1.0f), 0.0f);
+        getSmiley(mSmileys, fraction, divisions, mFromRange, mToRange,
+                mFaceCenter, mSmilePath, mCenterY);
+        invalidate();
     }
 
     private void onClickView(float x, float y) {


### PR DESCRIPTION
Bug in moveSmile function where the calculated fraction when selecting the last smiley would be barely above 1.0f. As an example, while debugging, the result was 1.000001f.

In the moveSmileByFraction function, if the fraction was not between 0.0f->1.0f, then it would return doing nothing. Thus, the solution is to clamp the fraction between 0.0f->1.0f and remove the if statement checking for a valid range.

This bug was only visible in certain instances because it depended on a number of variables whether the fraction was above 1.0f. This is why the bug was only present in certain builds, certain layouts, etc.