### PR TITLE
Fix issue #24

### DIFF
--- a/smilerating/src/main/java/com/hsalf/smilerating/SmileRating.java
+++ b/smilerating/src/main/java/com/hsalf/smilerating/SmileRating.java
@@ -318,7 +318,8 @@ public class SmileRating extends BaseRating {
                 mPathPaint.setColor((Integer) mColorEvaluator
                         .evaluate(mMainSmileyTransformaFraction, mPlaceHolderFacePaint.getColor(), mDrawingColor));
                 mBackgroundPaint.setColor((Integer) mColorEvaluator
-                        .evaluate(mMainSmileyTransformaFraction, mPlaceHolderCirclePaint.getColor(), mNormalColor));
+                        .evaluate(mMainSmileyTransformaFraction, mPlaceHolderCirclePaint.getColor(),
+                                (mSelectedSmile == TERRIBLE || mPreviousSmile == TERRIBLE) ? mAngryColor : mNormalColor));
                 mScaleMatrix.reset();
                 mSmilePath.computeBounds(mScaleRect, true);
                 float nonSelectedScale = mFloatEvaluator.evaluate(


### PR DESCRIPTION
Bug where clicking on terrible smiley the first time would result in it being colored normally instead of angry color.

When the previous selected state or new selected state of a smiley is NONE, then things are handled differently since there is no previous or next state to translate to. Instead, the background color is faded from deselected to selected. However, it was hardcoded to fade to normal color when there should be a check if the previous or next selected state and set to angry color if so.